### PR TITLE
Unify whitespace and fix comment typos.

### DIFF
--- a/ECS/Unity/Editor/Templates/91-ECS__Component Class-NewComponent.cs.txt
+++ b/ECS/Unity/Editor/Templates/91-ECS__Component Class-NewComponent.cs.txt
@@ -4,11 +4,11 @@ using System.Collections.Generic;
 using UnityEngine;
 
 namespace ECS {
-	// classes are slower than structs 
-	// its not recommendet to use this because it has an importend impact no the computation speed
-	// use this class if you deal with unity Monobehaviour scripts like Transform
-	[Serializable]
-	public class #SCRIPTNAME# : IComponent, ICloneable {
+    // classes are slower than structs 
+    // it's not recommended to use this because it has an important impact on the computation speed
+    // use this class if you deal with unity Monobehaviour scripts like Transform
+    [Serializable]
+    public class #SCRIPTNAME# : IComponent, ICloneable {
 
-	}	
+    }
 }

--- a/ECS/Unity/Editor/Templates/91-ECS__Component Struct-NewComponent.cs.txt
+++ b/ECS/Unity/Editor/Templates/91-ECS__Component Struct-NewComponent.cs.txt
@@ -4,10 +4,10 @@ using System.Collections.Generic;
 using UnityEngine;
 
 namespace ECS {
-	// structs are way faster than class 
-	// use this when ever you can it has an importen impact on the computation speedup
-	[Serializable]
-	public struct #SCRIPTNAME# : IComponent {
+    // structs are way faster than class 
+    // use this when ever you can it has an important impact on the computation speedup
+    [Serializable]
+    public struct #SCRIPTNAME# : IComponent {
 
-	}	
+    }
 }

--- a/ECS/Unity/Editor/Templates/91-ECS__ECSController-NewECSController.cs.txt
+++ b/ECS/Unity/Editor/Templates/91-ECS__ECSController-NewECSController.cs.txt
@@ -1,30 +1,29 @@
 ﻿using UnityEngine;
 
 namespace ECS {
-		
     // Use this class instead of the UnityStandardSystemRoot to create decoupled systems
     // you also have to create a custom EntityManager, because of the Injectionmanager that handles all EntityManagers as singletons
     //[InjectableDependency(LifeTime.Singleton)]
     //public class MyEntityManager : UnityEntityManager { }
     //[InjectableDependency(LifeTime.PerInstance)]
-    //class MySystemRoot : UnitySystemRoot<MyEntityManager> {}
-	
-	// Use this class to control the ECS System
-	// for different context replace ECSController<UnityStandardSystemRoot, EntityManager>  with your context classes
-	public class #SCRIPTNAME# : ECSController<UnityStandardSystemRoot, UnityEntityManager> {
-	
-		// Use this for initialization
-		protected override void Initialize() {
-			// You can eighver use this convention to add a system to the systemRoot
-			//AddSystem<MySystem>();
-			
-			// or you can use this for more controll over compositions of systems
-			//AddSystem(new MySystem());
-		}
+    //class MySystemRoot : UnitySystemRoot<MyEntityManager> { }
+    
+    // Use this class to control the ECS System
+    // for different context replace ECSController<UnityStandardSystemRoot, EntityManager>  with your context classes
+    public class #SCRIPTNAME# : ECSController<UnityStandardSystemRoot, UnityEntityManager> {
 
-		// Override this method if not all GameObjectEntities in the scene should be in the context of this system
-		// protected override void AddSceneEntitiesToSystem() {
+        // Use this for initialization
+        protected override void Initialize() {
+            // You can eighver use this convention to add a system to the systemRoot
+            //AddSystem<MySystem>();
+            
+            // or you can use this for more controll over compositions of systems
+            //AddSystem(new MySystem());
+        }
+
+        // Override this method if not all GameObjectEntities in the scene should be in the context of this system
+        // protected override void AddSceneEntitiesToSystem() {
             
         //}
-	}
+    }
 }

--- a/ECS/Unity/Editor/Templates/91-ECS__System-NewSystem.cs.txt
+++ b/ECS/Unity/Editor/Templates/91-ECS__System-NewSystem.cs.txt
@@ -3,29 +3,27 @@ using System.Collections.Generic;
 using UnityEngine;
 
 namespace ECS {
-	
-	 /// <summary>
+    /// <summary>
     /// Required Components: MyComponent
     /// </summary>
-	//use this tag to group systems for debugging purposes
-	//[DebugSystemGroup("MyGroup")] 
-	public class #SCRIPTNAME# : ComponentSystem {
-		
-		// this will inject all entities with components of type MyComponent 
-		// if you define multiple ComponentArrays with the [InjectTuple] tag
-		// you will only receive those entities with both Components
-		//[InjectTuple]
-		//ComponentArray<MyComponent> myComponent;		
-		
-		
-		// Use this for standard unity start function
-		public override void OnStart(){
-		
-		}
-		
-		// Use this for standard unity update function
-		public override void OnUpdate(){
-		
-		}
-	}
+    //use this tag to group systems for debugging purposes
+    //[DebugSystemGroup("MyGroup")] 
+    public class #SCRIPTNAME# : ComponentSystem {
+        
+        // this will inject all entities with components of type MyComponent 
+        // if you define multiple ComponentArrays with the [InjectTuple] tag
+        // you will only receive those entities with both Components
+        //[InjectTuple]
+        //ComponentArray<MyComponent> myComponent;        
+        
+        // Use this for standard unity start function
+        public override void OnStart() {
+        
+        }
+        
+        // Use this for standard unity update function
+        public override void OnUpdate() {
+        
+        }
+    }
 }

--- a/ECS/Unity/Editor/Templates/91-ECS__Wrapped Component Class-NewComponent.cs.txt
+++ b/ECS/Unity/Editor/Templates/91-ECS__Wrapped Component Class-NewComponent.cs.txt
@@ -4,18 +4,18 @@ using System.Collections.Generic;
 using UnityEngine;
 
 namespace ECS {
-	// classes are slower than structs 
-	// its not recommendet to use this because it has an importend impact no the computation speed
-	// use this class if you deal with unity Monobehaviour scripts like Transform
-	[Serializable]
-	public class #SCRIPTNAME#Component : IComponent, ICloneable {
+    // classes are slower than structs 
+    // its not recommended to use this because it has an important impact on the computation speed
+    // use this class if you deal with unity Monobehaviour scripts like Transform
+    [Serializable]
+    public class #SCRIPTNAME#Component : IComponent, ICloneable {
 
-		public object Clone() {
+        public object Clone() {
             return MemberwiseClone();
         }
-	}	
-	
-	// this wrapps the component tfor Scene & Prefab workflow	
-	[DisallowMultipleComponent]
-	public class #SCRIPTNAME# : ComponentWrapper<#SCRIPTNAME#Component>{}	
+    }
+    
+    // this wraps the component for Scene & Prefab workflow    
+    [DisallowMultipleComponent]
+    public class #SCRIPTNAME# : ComponentWrapper<#SCRIPTNAME#Component>{ }
 }

--- a/ECS/Unity/Editor/Templates/91-ECS__Wrapped Component Struct-NewComponent.cs.txt
+++ b/ECS/Unity/Editor/Templates/91-ECS__Wrapped Component Struct-NewComponent.cs.txt
@@ -4,14 +4,14 @@ using System.Collections.Generic;
 using UnityEngine;
 
 namespace ECS {
-	// structs are way faster than class 
-	// use this when ever you can it has an importen impact on the computation speedup
-	[Serializable]
-	public struct #SCRIPTNAME#Component : IComponent {
+    // structs are way faster than class 
+    // use this when ever you can it has an important impact on the computation speedup
+    [Serializable]
+    public struct #SCRIPTNAME#Component : IComponent {
 
-	}	
-	
-	// this wrapps the component tfor Scene & Prefab workflow	
-	[DisallowMultipleComponent]
-	public class #SCRIPTNAME# : ComponentDataWrapper<#SCRIPTNAME#Component>{}	
+    }
+    
+    // this wraps the component for Scene & Prefab workflow    
+    [DisallowMultipleComponent]
+    public class #SCRIPTNAME# : ComponentDataWrapper<#SCRIPTNAME#Component>{ }
 }


### PR DESCRIPTION
Get rid of leading and mixed tabs and spaces.
Fix typos in several comments.

I normally wouldn't have bothered with this type of commit, however since these are templates, I opted to, since I was changing them far too frequently. Also, since the templates changed recently, I figured it might be a good idea.
Feel free to accept or reject at your discretion.