### PR TITLE
Add Unity's CharacterController as an ECS component

### DIFF
--- a/ECS/Unity/Components/ECSCharacterController.cs
+++ b/ECS/Unity/Components/ECSCharacterController.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+// This is a wrapper around Unity's CharacterController component
+namespace ECS
+{
+    // classes are slower than structs 
+    // its not recommended to use this because it has an important impact on the computation speed
+    // use this class if you deal with unity Monobehaviour scripts like Transform
+    [Serializable]
+    public class CharacterControllerComponent : IComponent, ICloneable
+    {
+        public CharacterController characterController;
+
+        public object Clone() {
+            return MemberwiseClone();
+        }
+    }    
+    
+    // this wraps the component for Scene & Prefab workflow    
+    [DisallowMultipleComponent]
+    [HideInInspector]
+    [RequireComponent(typeof(CharacterController))]
+    public class ECSCharacterController : ComponentWrapper<CharacterControllerComponent>
+    {
+        private void Awake()
+        {
+            TypedComponent.characterController = gameObject.GetComponent<CharacterController>();
+        }
+    }
+}

--- a/ECS/Unity/Components/ECSCharacterController.cs.meta
+++ b/ECS/Unity/Components/ECSCharacterController.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 5ba47af66fd441e42be5f5eb8febfae8
+timeCreated: 1514692807
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ECS/Unity/GameObjectEntity.cs
+++ b/ECS/Unity/GameObjectEntity.cs
@@ -51,6 +51,11 @@ namespace ECS {
                 var ecsColliders = gameObject.AddComponent<ECSColliders>();
                 ecsColliders.hideFlags = HideFlags.HideInInspector;
             }
+
+            if (gameObject.GetComponent<CharacterController>() && !gameObject.GetComponent<ECSCharacterController>()) {
+                var ecsCharacterController = gameObject.AddComponent<ECSCharacterController>();
+                ecsCharacterController.hideFlags = HideFlags.HideInInspector;
+            }
         }
 
         public void SetEntity(Entity entity, EntityManager entityManager) {


### PR DESCRIPTION
For objects that don't use rigidbody's, the CharacterController is an
alternative. This adds it as an ECS component.