### PR TITLE
Add support for template installation from linux.

### DIFF
--- a/ECS/Unity/Editor/ECSMenus.cs
+++ b/ECS/Unity/Editor/ECSMenus.cs
@@ -86,7 +86,7 @@ public class ECSSetup : Editor {
             var unityDir = TemplatePath;
             if(!Directory.Exists(unityDir))
             {
-				EditorUtility.DisplayDialog("ECS Installation", "Setup not supported for your OS!\n Please copy the template folder content manually to:\n<UnityInstall>/" + unityTemplateDir + "\n\n and restart unity!", "ok");           
+                EditorUtility.DisplayDialog("ECS Installation", "Setup not supported for your OS!\n Please copy the template folder content manually to:\n<UnityInstall>/" + unityTemplateDir + "\n\n and restart unity!", "ok");           
                 return;
             }
 
@@ -133,7 +133,6 @@ public class ECSSetup : Editor {
             EditorUtility.DisplayDialog("ECS Setup", "SSomething went wrong!\n\n Error:\n" + ex.Message, "ok");
         }
     }
-
 
     [MenuItem("BrokenBricks/ECS/Enable Visual Debugging")]
     private static void EnableVisualDebugging() {

--- a/ECS/Unity/Editor/ECSMenus.cs
+++ b/ECS/Unity/Editor/ECSMenus.cs
@@ -7,12 +7,31 @@ using UnityEditor;
 using UnityEngine;
 
 public class ECSSetup : Editor {
-
 #if UNITY_EDITOR_WIN
-    private const string unityTemplateDir = @"\Editor\Data\Resources\ScriptTemplates";
+    private static string unityInstallDir = string.Empty;
+    private const string unityTemplateDir = @"Editor\Data\Resources\ScriptTemplates";
     private const string unityRegistryKey = @"Software\Unity Technologies\Installer\Unity\";
     private const string unityRegistryValue = @"Location x64";
+#elif UNITY_EDITOR_OSX
+    private const string unityInstallDir = @"/Applications/Unity/Unity.app/Contents";
+    private const string unityTemplateDir = @"Resources/ScriptTemplates";
+#else
+    private const string unityInstallDir = @"/opt/Unity";
+    private const string unityTemplateDir = @"Editor/Data/Resources/ScriptTemplates";
 #endif
+    private static bool enableTemplateValidation = true;
+
+    private static string TemplatePath {
+        get {
+            #if UNITY_EDITOR_WIN
+            if (string.IsNullOrEmpty(unityInstallDir)) {
+                var key = Microsoft.Win32.Registry.CurrentUser.OpenSubKey(unityRegistryKey, false);
+                unityInstallDir = (string)key.GetValue(unityRegistryValue);
+            }
+            #endif
+            return Path.Combine(unityInstallDir, unityTemplateDir);
+        }
+    }
 
     static readonly string[] files = {
             "91-ECS__Wrapped Component Class-NewComponent.cs",
@@ -23,27 +42,58 @@ public class ECSSetup : Editor {
             "91-ECS__ECSController-NewECSController.cs",
         };
 
+    [MenuItem("BrokenBricks/ECS/Install Templates", isValidateFunction: true)]
+    private static bool ValidateInstallTemplates() {
+        if (!enableTemplateValidation)
+            return true;
 
-    [MenuItem("BrokenBricks/ECS/Setup")]
-    private static void SetupECS() {
+        // Only allow installation if *none* of the files exist
+        if (files.All(s => !File.Exists(Path.Combine(TemplatePath, s + ".txt"))) && CanCreateFileInTemplates())
+            return true;
+
+        return false;
+    }
+
+    [MenuItem("BrokenBricks/ECS/Uninstall Templates", isValidateFunction: true)]
+    private static bool ValidateUninstallTemplates() {
+        if (!enableTemplateValidation)
+            return true;
+
+        // To make sure we can clean up properly, check if *any* of the template files exist
+        if (files.Any(s => File.Exists(Path.Combine(TemplatePath, s + ".txt"))) && CanCreateFileInTemplates())
+            return true;
+
+        return false;
+    }
+
+    private static bool CanCreateFileInTemplates() {
         try {
+            var testfile = Path.Combine(TemplatePath, ".test");
+            var stream = File.Create(testfile);
+            stream.Close();
+            File.Delete(testfile);
+            return true;
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return false;
+        }
+    }
 
-#if UNITY_EDITOR_WIN
-            Microsoft.Win32.RegistryKey key = Microsoft.Win32.Registry.CurrentUser.OpenSubKey(unityRegistryKey, false);
-            string unityInstallDir = (string)key.GetValue(unityRegistryValue);
-            string destTempFolderPath = unityInstallDir + unityTemplateDir;
-#elif UNITY_EDITOR_OSX
-            string destTempFolderPath = @"/Applications/Unity/Unity.app/Contents/Resources/ScriptTemplates";
-#else
-            string destTempFolderPath ="";
-            EditorUtility.DisplayDialog("ECS Installation", "Setup not supported for your OS!\n Please copy the template folder content manualy to:\n"+ unityTemplateDir + "\n\n and restart unity!", "ok");           
-            return;
-#endif
+    [MenuItem("BrokenBricks/ECS/Install Templates")]
+    private static void InstallTemplates() {
+        try {
+            var unityDir = TemplatePath;
+            if(!Directory.Exists(unityDir))
+            {
+				EditorUtility.DisplayDialog("ECS Installation", "Setup not supported for your OS!\n Please copy the template folder content manually to:\n<UnityInstall>/" + unityTemplateDir + "\n\n and restart unity!", "ok");           
+                return;
+            }
 
             foreach (var file in files) {
                 var assetGUID = AssetDatabase.FindAssets(file)[0];
                 var filePath = AssetDatabase.GUIDToAssetPath(assetGUID);
-                File.Copy(Path.Combine(Directory.GetParent(Application.dataPath).FullName, filePath), Path.Combine(destTempFolderPath, Path.GetFileName(filePath)), true);
+                File.Copy(Path.Combine(Directory.GetParent(Application.dataPath).FullName, filePath), Path.Combine(unityDir, Path.GetFileName(filePath)), true);
                 //var filePath = AssetDatabase.GetAssetPath();
             }
             EditorUtility.DisplayDialog("ECS Setup", "Installation completed!\nPlease restart unity to access all functionalities!", "ok");
@@ -58,25 +108,19 @@ public class ECSSetup : Editor {
         }
     }
 
-    [MenuItem("BrokenBricks/ECS/Uninstall")]
+    [MenuItem("BrokenBricks/ECS/Uninstall Templates")]
     private static void UninstallECS() {
-#if UNITY_EDITOR_WIN
-        Microsoft.Win32.RegistryKey key = Microsoft.Win32.Registry.CurrentUser.OpenSubKey(unityRegistryKey, false);
-        string unityInstallDir = (string)key.GetValue(unityRegistryValue);
-        string destTempFolderPath = unityInstallDir + unityTemplateDir;
-#elif UNITY_EDITOR_OSX
-        string destTempFolderPath = @"/Applications/Unity/Unity.app/Contents/Resources/ScriptTemplates";
-#else
-        string destTempFolderPath ="";
-        EditorUtility.DisplayDialog("ECS Uninstallation", "Uninstallation not supported for your OS!\n Please delete the template folder content manualy from:\n"+ unityTemplateDir + "\n\n and restart unity!", "ok");           
-        return;           
-#endif
-
+        string unityDir = TemplatePath;
+        if(!Directory.Exists(unityDir))
+        {
+            EditorUtility.DisplayDialog("ECS Uninstallation", "Uninstallation not supported for your OS!\n Please delete the template folder content manually from:\n<Unityinstall>/"+ unityTemplateDir + "\n\n and restart unity!", "ok");           
+            return;
+        }
 
         try {
             foreach (var file in files)
             {
-                File.Delete(Path.Combine(destTempFolderPath, file + ".txt"));
+                File.Delete(Path.Combine(unityDir, file + ".txt"));
             }
             EditorUtility.DisplayDialog("ECS Uninstallation", "Uninstallation completed!\nPlease restart unity!", "ok");
         }
@@ -91,7 +135,7 @@ public class ECSSetup : Editor {
     }
 
 
-    [MenuItem("BrokenBricks/ECS/Enable Visual Debuggin")]
+    [MenuItem("BrokenBricks/ECS/Enable Visual Debugging")]
     private static void EnableVisualDebugging() {
         foreach (BuildTargetGroup buildTarget in Enum.GetValues(typeof(BuildTargetGroup))) {
             if (buildTarget == BuildTargetGroup.Unknown) {
@@ -108,12 +152,12 @@ public class ECSSetup : Editor {
         }
     }
 
-    [MenuItem("BrokenBricks/ECS/Enable Visual Debuggin", isValidateFunction:true)]
+    [MenuItem("BrokenBricks/ECS/Enable Visual Debugging", isValidateFunction:true)]
     private static bool ValidateEnableVisualDebugging() {
        return !PlayerSettings.GetScriptingDefineSymbolsForGroup(BuildTargetGroup.Standalone).Contains("ECS_DEBUG");
     }
 
-    [MenuItem("BrokenBricks/ECS/Disable Visual Debuggin")]
+    [MenuItem("BrokenBricks/ECS/Disable Visual Debugging")]
     private static void DisableVisualDebugging() {
         foreach (BuildTargetGroup buildTarget in Enum.GetValues(typeof(BuildTargetGroup))) {
             if (buildTarget == BuildTargetGroup.Unknown) {
@@ -127,7 +171,7 @@ public class ECSSetup : Editor {
         }
     }
 
-    [MenuItem("BrokenBricks/ECS/Disable Visual Debuggin", isValidateFunction: true)]
+    [MenuItem("BrokenBricks/ECS/Disable Visual Debugging", isValidateFunction: true)]
     private static bool ValidateDisableVisualDebugging() {
         return PlayerSettings.GetScriptingDefineSymbolsForGroup(BuildTargetGroup.Standalone).Contains("ECS_DEBUG");
     }


### PR DESCRIPTION
This adds support for automatic template installation in linux, if permissions are set (or run as root).
Now it checks for permissions, and will disable the menu items if no permissions. Also the Install/Uninstall menu items will toggle as appropriate based on the existence of the template files in the target location.
This unifies the code more, so the platform specific code is more centralized.

Unity default install location on linux is /opt/Unity, so that is used on linux.

I also changed the menu item names, for clarity.

After #10 there was a compile error on linux again, which is why I started this task.